### PR TITLE
[community] Add HPXKH

### DIFF
--- a/community/tw/HPXKH/README.md
+++ b/community/tw/HPXKH/README.md
@@ -1,0 +1,25 @@
+# HPXKH
+
+## 社群資訊 / Community Information
+
+HPX 是數位產品(網站/App)設計與企劃工作者的交流社群平台。尤其是對創新產品企劃或使用者經驗設計有興趣的人。社群透過多元活動/讀書會，推動實務經驗分享與互動交流，創造有效的學習成長，也促成各種合作機會。
+
+HPXKH 即是 HPX 的高雄讀書會，提供高雄愛書的朋友們一個呼朋引伴的環境。任何社員都可以在這裡舉辦讀書聚會，開啟多元化主題的交流，舉凡產品、服務、行銷、設計、人類、心理、哲學、社會、商業、管理、技術、科技、創業。後續透過輕鬆聚或大聚互相分享彼此的心得，以書會友，共同成長。
+
+
+## 活動報名連結 / Registration link
+
+https://hpxkh.kktix.cc/
+
+## 主辦單位資訊 / Group Information
+
+- Category: community
+- Name: HPXKH
+- Title: Happy People Cross for Kaohsiung
+- Keywords: 南部, 讀書會, 網站, app, 設計, 企劃, 使用者經驗, 創業
+- Contact: hpxkhbc@gmail.com
+- City: Kaohsiung
+- Social-Media
+    - Facebook: https://www.facebook.com/groups/KaohsiungHPX/
+
+

--- a/community/tw/HPXKH/package.json
+++ b/community/tw/HPXKH/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "HPXKH",
+  "title": "HPX 高雄讀書會",
+  "description": "HPXKH 是 HPX 的高雄讀書會，提供高雄愛書的朋友們一個呼朋引伴的環境。任何社員都可以在這裡舉辦讀書聚會，開啟多元化主題的交流，舉凡產品、服務、行銷、設計、人類、心理、哲學、社會、商業、管理、技術、科技、創業。後續透過輕鬆聚或大聚互相分享彼此的心得，以書會友，共同成長。",
+  "countrycode": "tw",
+  "city": "Kaohsiung",
+  "contact": "hpxkhbc@gmail.com",
+  "keywords": [
+    "高雄",
+    "讀書會",
+    "使用者經驗",
+    "設計",
+    "心理學",
+    "哲學",
+    "創業",
+    "網站",
+    "app"
+  ],
+  "registration": {
+    "type": "kktix",
+    "url": "https://hpxkh.kktix.cc/"
+  },
+  "social-media": [
+    {
+      "type": "facebook",
+      "urls": [
+        "https://www.facebook.com/groups/KaohsiungHPX/"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
加入 HPXKH 社群
HPXKH 即為 Happy People Cross for Kaohsiung, 是 HPX 在高雄在地的讀書會。提供高雄愛書的朋友們一個呼朋引伴的環境。任何社員都可以在這裡舉辦讀書聚會，開啟多元化主題的交流，舉凡產品、服務>、行銷、設計、人類、心理、哲學、社會、商業、管理、技術、科技、創業。後續透過輕鬆聚或大聚互相分享彼此的心得，以書會友，共同成長。